### PR TITLE
Remove debug print statement from CbAS

### DIFF
--- a/flexs/baselines/explorers/cbas_dbas.py
+++ b/flexs/baselines/explorers/cbas_dbas.py
@@ -154,7 +154,6 @@ class CbAS(flexs.Explorer):
                 all_samples_and_weights[0],
                 all_samples_and_weights[1],
             )
-            print(self.model.cost - previous_model_cost, len(proposals))
 
             # calculate the scores of the new samples using the model
             scores = self.model.get_fitness(proposals)

--- a/flexs/baselines/explorers/genetic_algorithm.py
+++ b/flexs/baselines/explorers/genetic_algorithm.py
@@ -99,7 +99,7 @@ class GeneticAlgorithm(flexs.Explorer):
     ) -> Tuple[np.ndarray, np.ndarray]:
         """Propose top `sequences_batch_size` sequences for evaluation."""
         # Set the torch seed by generating a random integer from the pre-seeded self.rng
-        torch.manual_seed(self.rng.integers(-(2 ** 31), 2 ** 31))
+        torch.manual_seed(self.rng.integers(-(2**31), 2**31))
 
         measured_sequence_set = set(measured_sequences["sequence"])
 

--- a/flexs/baselines/models/noisy_abstract_model.py
+++ b/flexs/baselines/models/noisy_abstract_model.py
@@ -90,7 +90,7 @@ class NoisyAbstractModel(flexs.Model):
             else:
                 noise = np.random.choice(list(self.cache.values()))
 
-            alpha = self.ss ** distance
+            alpha = self.ss**distance
             new_fitnesses.append(alpha * signal + (1 - alpha) * noise)
 
         fitnesses[~cached] = new_fitnesses

--- a/flexs/utils/replay_buffers.py
+++ b/flexs/utils/replay_buffers.py
@@ -212,8 +212,8 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         """Store experience and priority."""
         super().store(obs, act, rew, next_obs)
 
-        self.sum_tree[self.tree_ptr] = self.max_priority ** self.alpha
-        self.min_tree[self.tree_ptr] = self.max_priority ** self.alpha
+        self.sum_tree[self.tree_ptr] = self.max_priority**self.alpha
+        self.min_tree[self.tree_ptr] = self.max_priority**self.alpha
         self.tree_ptr = (self.tree_ptr + 1) % self.max_size
 
     def sample_batch(self, beta: float = 0.4) -> Dict[str, np.ndarray]:
@@ -246,8 +246,8 @@ class PrioritizedReplayBuffer(ReplayBuffer):
             assert priority > 0
             assert 0 <= idx < len(self)
 
-            self.sum_tree[idx] = priority ** self.alpha
-            self.min_tree[idx] = priority ** self.alpha
+            self.sum_tree[idx] = priority**self.alpha
+            self.min_tree[idx] = priority**self.alpha
 
             self.max_priority = max(self.max_priority, priority)
 


### PR DESCRIPTION
Given that FLEXS is supposed to be a package, it doesn't make sense to have raw print statements that can't be turned off inside of default implementations.